### PR TITLE
Add Iran's government fleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,24 @@ http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015
 
 ### Algeria
 
-* '7T-VPP' : 'Airbus A340 VIP used by Algerian government',
-* '7T-VPF' : 'ATR42 used by Algerian government',
-* '7T-VPE' : 'ATR42 used by Algerian government',
-* '7T-VPS' : 'Gulfstream IV used by Algerian government',
-* '7T-VPC' : 'Gulfstream IV used by Algerian government',
-* '7T-VPM' : 'Gulfstream IV used by Algerian government',
-* '7T-VPG' : 'Gulfstream V used by Algerian government',
+* '7T-VPP' : 'Airbus A340 VIP used by Algerian government'
+* '7T-VPF' : 'ATR42 used by Algerian government'
+* '7T-VPE' : 'ATR42 used by Algerian government'
+* '7T-VPS' : 'Gulfstream IV used by Algerian government'
+* '7T-VPC' : 'Gulfstream IV used by Algerian government'
+* '7T-VPM' : 'Gulfstream IV used by Algerian government'
+* '7T-VPG' : 'Gulfstream V used by Algerian government'
 
 ### Angola
-* 'D2-EYU' : 'De Havilland Dash 8 used by Angola government',
-* 'D2-EEA' : 'De Havilland Dash 8 used by Angola government',
-* 'D2-EEB' : 'De Havilland Dash 8 used by Angola government',
- 
+* 'D2-EYU' : 'De Havilland Dash 8 used by Angola government'
+* 'D2-EEA' : 'De Havilland Dash 8 used by Angola government'
+* 'D2-EEB' : 'De Havilland Dash 8 used by Angola government'
+
 ### Azerbaijan
 
 * '4K-AIO1' : 'Boeing 767 "Baku 1" used by Azerbaijan government'
 * '4K-AI06' : 'Gulfstream G550 used by Azerbaijan government'
- 
+
 ### Bahrain
 
 * 'A9C-HMK' : 'Boeing 747 used by the king of Bahrain'
@@ -45,7 +45,7 @@ http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015
 
 * 'EW-001PA' : 'Boeing 737 used by Belarus government'
 * 'EW-001PB' : 'Boeing 767 used by Belarus government'
- 
+
 ### Cameroon
 
 * 'TJ-AAC' : 'Boeing 767 used by Cameroon government'
@@ -55,8 +55,8 @@ http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015
 * 'TT-ABC' : 'MD-87 used by the government of Chad'
 
 ### Gabon
-* 'TR-KJD' : 'ATR 42M used by Gabonese government',
-* 'TR-KPR' : 'Boeing 777 VIP used by Gabonese government',
+* 'TR-KJD' : 'ATR 42M used by Gabonese government'
+* 'TR-KPR' : 'Boeing 777 VIP used by Gabonese government'
 
 ### Equatorial Guinea
 
@@ -66,13 +66,21 @@ http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015
 * '3C-LLU' : 'Boeing 767 used by Equatorial Guinea government'
 * 'CS-TQX' : 'Boeing 777 used by Equatorial Guinea government'
 
+### Iran
+* 'EP-AJA' : 'Airbus A340 used by the Iran government'
+* 'EP-AJC' : 'Airbus A320 used by the Iran government'
+* 'EP-AJD' : 'Boeing 707 used by the Iran government'
+* 'EP-AGA' : 'Boeing 737 used by the Iran government'
+* 'EP-AGB' : 'Airbus A321 used by the Iran government'
+* 'EP-TFI' : 'Dassault Falcon 50 used by the Iran government'
+
 ### Ivory Coast
-* 'TU-VAD' : 'Gulfstream IV used by Ivory Coast government',
-* 'TU-VAS' : 'A319 VIP used by Ivory Coast government',
+* 'TU-VAD' : 'Gulfstream IV used by Ivory Coast government'
+* 'TU-VAS' : 'A319 VIP used by Ivory Coast government'
 
 ### Jordan
-* 'VQ-BDD' : 'Airbus A318 Elite used by Jordanian government',
- 
+* 'VQ-BDD' : 'Airbus A318 Elite used by Jordanian government'
+
 ### Kazakhstan
 
 * 'P4-KAZ' : 'Boeing 737 used by Kazakhstan government'
@@ -82,17 +90,17 @@ http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015
 
 ### Kuwait
 
-* '9K-GBA' : 'Airbus A340 VIP used by Kuwait government',
-* '9K-GBB' : 'Airbus A340 VIP used by Kuwait government',
-* '9K-AKD' : 'Airbus A320 VIP used by Kuwait government',
-* '9K-GEA' : 'Airbus A319 VIP used by Kuwait government',
-* '9K-GCC' : 'Boeing 737 VIP used by Kuwait government',
-* '9K-GAA' : 'Boeing 747 VIP used by Kuwait government',
-* '9K-AJD' : 'Gulfstream V used by Kuwait government',
-* '9K-AJE' : 'Gulfstream V used by Kuwait government',
-* '9K-AJF' : 'Gulfstream V used by Kuwait government',
-* '9K-GFA' : 'Gulfstream 550 used by Kuwait government',
- 
+* '9K-GBA' : 'Airbus A340 VIP used by Kuwait government'
+* '9K-GBB' : 'Airbus A340 VIP used by Kuwait government'
+* '9K-AKD' : 'Airbus A320 VIP used by Kuwait government'
+* '9K-GEA' : 'Airbus A319 VIP used by Kuwait government'
+* '9K-GCC' : 'Boeing 737 VIP used by Kuwait government'
+* '9K-GAA' : 'Boeing 747 VIP used by Kuwait government'
+* '9K-AJD' : 'Gulfstream V used by Kuwait government'
+* '9K-AJE' : 'Gulfstream V used by Kuwait government'
+* '9K-AJF' : 'Gulfstream V used by Kuwait government'
+* '9K-GFA' : 'Gulfstream 550 used by Kuwait government'
+
 ### Libya
 
 * '5A-ONE' : 'Airbus A340 used Libyan government'
@@ -110,26 +118,26 @@ http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015
 ### Qatar
 
 * 'VQ-BSK' : 'Boeing 747 used by the royal family of Qatar'
-*  'VQ-BSK' : 'Boeing 747 used by the royal family of Qatar',
-*  'A7-AAG' : 'A320 used by the royal family of Qatar',
-*  'A7-AAH' : 'A340 used by the royal family of Qatar',
-*  'A7-AAM' : 'Bombardier BD-700 used by the royal family of Qatar',
-*  'A7-AFE' : 'A310 used by the royal family of Qatar',
-*  'A7-HHE' : 'Boeing 747 used by the royal family of Qatar',
-*  'A7-HHH' : 'A340 used by the royal family of Qatar',
-*  'A7-HHJ' : 'A319 used by the royal family of Qatar',
+*  'VQ-BSK' : 'Boeing 747 used by the royal family of Qatar'
+*  'A7-AAG' : 'A320 used by the royal family of Qatar'
+*  'A7-AAH' : 'A340 used by the royal family of Qatar'
+*  'A7-AAM' : 'Bombardier BD-700 used by the royal family of Qatar'
+*  'A7-AFE' : 'A310 used by the royal family of Qatar'
+*  'A7-HHE' : 'Boeing 747 used by the royal family of Qatar'
+*  'A7-HHH' : 'A340 used by the royal family of Qatar'
+*  'A7-HHJ' : 'A319 used by the royal family of Qatar'
 *  'A7-HHK' : 'A340 used by the royal family of Qatar'
 *  'A7-HHM' : 'A330 used by the royal family of Qatar'
-*  'A7-HJJ' : 'A330 used by the royal family of Qatar',
-*  'A7-HSJ' : 'A320 used by the royal family of Qatar',
-*  'A7-MBK' : 'A320 used by the royal family of Qatar',
-*  'A7-MED' : 'A319 used by the royal family of Qatar',
-*  'A7-MHH' : 'A319 used by the royal family of Qatar',
-*  'VP-BAT' : 'Boeing 747 used by the royal family of Qatar',
+*  'A7-HJJ' : 'A330 used by the royal family of Qatar'
+*  'A7-HSJ' : 'A320 used by the royal family of Qatar'
+*  'A7-MBK' : 'A320 used by the royal family of Qatar'
+*  'A7-MED' : 'A319 used by the royal family of Qatar'
+*  'A7-MHH' : 'A319 used by the royal family of Qatar'
+*  'VP-BAT' : 'Boeing 747 used by the royal family of Qatar'
 
 ### Russia
-* 'RA-96016' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
-* 'RA-96017' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
+* 'RA-96016' : 'Ilyushin Il-96 used Russian president Vladimir Putin'
+* 'RA-96017' : 'Ilyushin Il-96 used Russian president Vladimir Putin'
 
 ### Saudi Arabia
 
@@ -147,7 +155,6 @@ http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015
 * 'ST-PRA' : 'Il-62 used by Omar Al-Bashir'
 
 ### Turkmenistan
-* 'EZ-A777' : 'Boeing 777 VIP used by Turkmenistan government',
-* 'EZ-A007' : 'Boeing 737 VIP used by Turkmenistan government',
-* 'EZ-B024' : 'Challenger 870 used by Turkmenistan government',
-
+* 'EZ-A777' : 'Boeing 777 VIP used by Turkmenistan government'
+* 'EZ-A007' : 'Boeing 737 VIP used by Turkmenistan government'
+* 'EZ-B024' : 'Challenger 870 used by Turkmenistan government'

--- a/README.md
+++ b/README.md
@@ -1,160 +1,149 @@
 # GVA Dictator Alert
 
-This TwitterBot is tracking planes registered to authoritarian regimes landing and leaving Geneva Airport. The results are posted on:
-https://twitter.com/GVA_Watcher
+This Twitter bot is tracking planes registered to authoritarian regimes landing and leaving Geneva Airport. The results are posted on:
+[@GVA_Watcher](https://twitter.com/GVA_Watcher)
 
 Help us grow this list by sending new planes registrations to francois@vesper.media
 
-Project by <a href="https://twitter.com/julienpilet">@julienpilet</a> and <a href="https://twitter.com/FrancoisPilet">@FrancoisPilet</a>
+Project by [@julienpilet](https://twitter.com/julienpilet) and [@FrancoisPilet](https://twitter.com/FrancoisPilet)
 
 ## Who's a dictator?
 
 GVA Dictator Alert is tracking planes registered to or used by governments described as "authoritarian regimes" according to the Democracy Index (2015) compiled by the Economist Intelligence Unit.
 
-Read more about the Democracy Index here:
-https://en.wikipedia.org/wiki/Democracy_Index
-http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015
+To read more about the Democracy Index, consult: [Democracy Index - Wikipedia](https://en.wikipedia.org/wiki/Democracy_Index) and [Democracy Index 2015: Democracy in an age of anxiety](http://www.eiu.com/public/topical_report.aspx?campaignid=DemocracyIndex2015)
 
 ## Current list of tracked planes:
 
 ### Algeria
-
-* '7T-VPP' : 'Airbus A340 VIP used by Algerian government'
-* '7T-VPF' : 'ATR42 used by Algerian government'
-* '7T-VPE' : 'ATR42 used by Algerian government'
-* '7T-VPS' : 'Gulfstream IV used by Algerian government'
-* '7T-VPC' : 'Gulfstream IV used by Algerian government'
-* '7T-VPM' : 'Gulfstream IV used by Algerian government'
-* '7T-VPG' : 'Gulfstream V used by Algerian government'
+* **7T-VPP**: Airbus A340 VIP used by Algerian government
+* **7T-VPF**: ATR42 used by Algerian government
+* **7T-VPE**: ATR42 used by Algerian government
+* **7T-VPS**: Gulfstream IV used by Algerian government
+* **7T-VPC**: Gulfstream IV used by Algerian government
+* **7T-VPM**: Gulfstream IV used by Algerian government
+* **7T-VPG**: Gulfstream V used by Algerian government
 
 ### Angola
-* 'D2-EYU' : 'De Havilland Dash 8 used by Angola government'
-* 'D2-EEA' : 'De Havilland Dash 8 used by Angola government'
-* 'D2-EEB' : 'De Havilland Dash 8 used by Angola government'
+* **D2-EYU**: De Havilland Dash 8 used by Angola government
+* **D2-EEA**: De Havilland Dash 8 used by Angola government
+* **D2-EEB**: De Havilland Dash 8 used by Angola government
 
 ### Azerbaijan
-
-* '4K-AIO1' : 'Boeing 767 "Baku 1" used by Azerbaijan government'
-* '4K-AI06' : 'Gulfstream G550 used by Azerbaijan government'
+* **4K-AIO1**: Boeing 767 "Baku 1" used by Azerbaijan government
+* **4K-AI06**: Gulfstream G550 used by Azerbaijan government
 
 ### Bahrain
+* **A9C-HMK**: Boeing 747 used by the king of Bahrain
 
-* 'A9C-HMK' : 'Boeing 747 used by the king of Bahrain'
+#### Belarus
+* **EW-001PA**: Boeing 737 used by Belarus government
+* **EW-001PB**: Boeing 767 used by Belarus government
 
-### Belarus
+#### Cameroon
+* **TJ-AAC**: Boeing 767 used by Cameroon government
 
-* 'EW-001PA' : 'Boeing 737 used by Belarus government'
-* 'EW-001PB' : 'Boeing 767 used by Belarus government'
+#### Chad
+* **TT-ABC**: MD-87 used by the government of Chad
 
-### Cameroon
+#### Equatorial Guinea
+* **3C-EGE**: Boeing 737 used by Teodoro Obiang, Equatorial Guinea
+* **3C-ONM**: Dassault 900B used by Teodorin Obiang, Equatorial Guinea
+* **3C-LGE**: Falcon 50 used by Equatorial Guinea government
+* **3C-LLU**: Boeing 767 used by Equatorial Guinea government
+* **CS-TQX**: Boeing 777 used by Equatorial Guinea government
 
-* 'TJ-AAC' : 'Boeing 767 used by Cameroon government'
+#### Gabon
+* **TR-KJD**: ATR 42M used by Gabonese government
+* **TR-KPR**: Boeing 777 VIP used by Gabonese government
 
-### Chad
+#### Iran
+* **EP-AJA**: Airbus A340 used by the Iran government
+* **EP-AJC**: Airbus A320 used by the Iran government
+* **EP-AJD**: Boeing 707 used by the Iran government
+* **EP-AGA**: Boeing 737 used by the Iran government
+* **EP-AGB**: Airbus A321 used by the Iran government
+* **EP-TFI**: Dassault Falcon 50 used by the Iran government
 
-* 'TT-ABC' : 'MD-87 used by the government of Chad'
+#### Ivory Coast
+* **TU-VAD**: Gulfstream IV used by Ivory Coast government
+* **TU-VAS**: A319 VIP used by Ivory Coast government
 
-### Gabon
-* 'TR-KJD' : 'ATR 42M used by Gabonese government'
-* 'TR-KPR' : 'Boeing 777 VIP used by Gabonese government'
+#### Jordan
+* **VQ-BDD**: Airbus A318 Elite used by Jordanian government
 
-### Equatorial Guinea
+#### Kazakhstan
+* **P4-KAZ**: Boeing 737 used by Kazakhstan government
+* **UP-A2001**: Airbus A320 used by Kazakhstan government
+* **UP-A3001**: Airbus A330 used by Kazakhstan government
+* **UP-B5701**: Boeing 757 used by Kazakhstan government
 
-* '3C-EGE' : 'Boeing 737 used by Teodoro Obiang, Equatorial Guinea'
-* '3C-ONM' : 'Dassault 900B used by Teodorin Obiang, Equatorial Guinea'
-* '3C-LGE' : 'Flacon 50 used by Equatorial Guinea government'
-* '3C-LLU' : 'Boeing 767 used by Equatorial Guinea government'
-* 'CS-TQX' : 'Boeing 777 used by Equatorial Guinea government'
+#### Kuwait
+* **9K-GBA**: Airbus A340 VIP used by Kuwait government
+* **9K-GBB**: Airbus A340 VIP used by Kuwait government
+* **9K-AKD**: Airbus A320 VIP used by Kuwait government
+* **9K-GEA**: Airbus A319 VIP used by Kuwait government
+* **9K-GCC**: Boeing 737 VIP used by Kuwait government
+* **9K-GAA**: Boeing 747 VIP used by Kuwait government
+* **9K-AJD**: Gulfstream V used by Kuwait government
+* **9K-AJE**: Gulfstream V used by Kuwait government
+* **9K-AJF**: Gulfstream V used by Kuwait government
+* **9K-GFA**: Gulfstream 550 used by Kuwait government
 
-### Iran
-* 'EP-AJA' : 'Airbus A340 used by the Iran government'
-* 'EP-AJC' : 'Airbus A320 used by the Iran government'
-* 'EP-AJD' : 'Boeing 707 used by the Iran government'
-* 'EP-AGA' : 'Boeing 737 used by the Iran government'
-* 'EP-AGB' : 'Airbus A321 used by the Iran government'
-* 'EP-TFI' : 'Dassault Falcon 50 used by the Iran government'
+#### Libya
+* **5A-ONE**: Airbus A340 used by Libyan government
 
-### Ivory Coast
-* 'TU-VAD' : 'Gulfstream IV used by Ivory Coast government'
-* 'TU-VAS' : 'A319 VIP used by Ivory Coast government'
+#### Oman
+* **A4O-AJ**: Airbus A319 of the Oman royal family
+* **A4O-AA**: Airbus A320 of the Oman royal family
+* **A4O-OMN**: Boeing 747 of the Oman royal family
+* **A4O-HMS**: Boeing 747 of the Oman royal family
+* **A4O-SO**: Boeing 747 of the Oman royal family
+* **A4O-AD**: Gulfstream G550 of the Oman royal family
+* **A4O-AE**: Gulfstream G550 of the Oman royal family
 
-### Jordan
-* 'VQ-BDD' : 'Airbus A318 Elite used by Jordanian government'
+#### Qatar
+* **VQ-BSK**: Boeing 747 used by the royal family of Qatar
+* **A7-AAG**: A320 used by the royal family of Qatar
+* **A7-AAH**: A340 used by the royal family of Qatar
+* **A7-AAM**: Bombardier BD-700 used by the royal family of Qatar
+* **A7-AFE**: A310 used by the royal family of Qatar
+* **A7-HHE**: Boeing 747 used by the royal family of Qatar
+* **A7-HHH**: Airbus A340 used by the royal family of Qatar
+* **A7-HHJ**: Airbus A319 used by the royal family of Qatar
+* **A7-HHK**: Airbus A340 used by the royal family of Qatar
+* **A7-HHM**: Airbus A330 used by the royal family of Qatar
+* **A7-HJJ**: Airbus A330 used by the royal family of Qatar
+* **A7-HSJ**: Airbus A320 used by the royal family of Qatar
+* **A7-MBK**: Airbus A320 used by the royal family of Qatar
+* **A7-MED**: Airbus A319 used by the royal family of Qatar
+* **A7-MHH**: Airbus A319 used by the royal family of Qatar
+* **VP-BAT**: Boeing 747 used by the royal family of Qatar
 
-### Kazakhstan
+#### Russia
+* **RA-96016**: Ilyushin Il-96 used Russian president Vladimir Putin
+* **RA-96017**: Ilyushin Il-96 used Russian president Vladimir Putin
 
-* 'P4-KAZ' : 'Boeing 737 used by Kazakhstan government'
-* 'UP-A2001' : 'Airbus A320 used by Kazakhstan government'
-* 'UP-A3001' : 'Airbus A330 used by Kazakhstan government'
-* 'UP-B5701' : 'Boeing 757 used by Kazakhstan government'
+#### Saudi Arabia
+* **HZ-WBT7**: Prince Al Waleed's Boeing 747
+* **HZ-WBT5**: Prince Al Waleed's Hawker
+* **HZ-HMS2**: Airbus A340 for use by the royal family
+* **HZ-HMS1**: Boeing 747 registered to Prince Sultan Bin Abdulaziz
+* **HZ-HM1B**: Boeing 747 for the use of the royal family
+* **HZ-HM1A**: Boeing 747 for the use of the royal family
+* **HZ-HM1C**: Boeing 747 for the use of the royal family
 
-### Kuwait
+#### Sudan
+* **ST-PRM**: Antonov An-72 of the Sudanese government
+* **ST-PRA**: Ilyushin Il-62 used by Omar Al-Bashir
 
-* '9K-GBA' : 'Airbus A340 VIP used by Kuwait government'
-* '9K-GBB' : 'Airbus A340 VIP used by Kuwait government'
-* '9K-AKD' : 'Airbus A320 VIP used by Kuwait government'
-* '9K-GEA' : 'Airbus A319 VIP used by Kuwait government'
-* '9K-GCC' : 'Boeing 737 VIP used by Kuwait government'
-* '9K-GAA' : 'Boeing 747 VIP used by Kuwait government'
-* '9K-AJD' : 'Gulfstream V used by Kuwait government'
-* '9K-AJE' : 'Gulfstream V used by Kuwait government'
-* '9K-AJF' : 'Gulfstream V used by Kuwait government'
-* '9K-GFA' : 'Gulfstream 550 used by Kuwait government'
+#### Turkmenistan
+* **EZ-A777**: Boeing 777 VIP used by Turkmenistan government
+* **EZ-A007**: Boeing 737 VIP used by Turkmenistan government
+* **EZ-B024**: Challenger 870 used by Turkmenistan government
 
-### Libya
+## Contributors
+* [@pedrofelipee](https://twitter.com/pedrofelipee)
 
-* '5A-ONE' : 'Airbus A340 used Libyan government'
-
-### Oman
-
-* 'A4O-AJ' : 'A319 of the Oman royal family'
-* 'A4O-AA' : 'A320 of the Oman royal family'
-* 'A4O-OMN' : 'B747 of the Oman royal family'
-* 'A4O-HMS' : 'B747 of the Oman royal family'
-* 'A4O-SO' : 'B747 of the Oman royal family'
-* 'A4O-AD' : 'Gulfstream of the Oman royal family'
-* 'A4O-AE' : 'Gulfstream of the Oman royal family'
-
-### Qatar
-
-* 'VQ-BSK' : 'Boeing 747 used by the royal family of Qatar'
-*  'VQ-BSK' : 'Boeing 747 used by the royal family of Qatar'
-*  'A7-AAG' : 'A320 used by the royal family of Qatar'
-*  'A7-AAH' : 'A340 used by the royal family of Qatar'
-*  'A7-AAM' : 'Bombardier BD-700 used by the royal family of Qatar'
-*  'A7-AFE' : 'A310 used by the royal family of Qatar'
-*  'A7-HHE' : 'Boeing 747 used by the royal family of Qatar'
-*  'A7-HHH' : 'A340 used by the royal family of Qatar'
-*  'A7-HHJ' : 'A319 used by the royal family of Qatar'
-*  'A7-HHK' : 'A340 used by the royal family of Qatar'
-*  'A7-HHM' : 'A330 used by the royal family of Qatar'
-*  'A7-HJJ' : 'A330 used by the royal family of Qatar'
-*  'A7-HSJ' : 'A320 used by the royal family of Qatar'
-*  'A7-MBK' : 'A320 used by the royal family of Qatar'
-*  'A7-MED' : 'A319 used by the royal family of Qatar'
-*  'A7-MHH' : 'A319 used by the royal family of Qatar'
-*  'VP-BAT' : 'Boeing 747 used by the royal family of Qatar'
-
-### Russia
-* 'RA-96016' : 'Ilyushin Il-96 used Russian president Vladimir Putin'
-* 'RA-96017' : 'Ilyushin Il-96 used Russian president Vladimir Putin'
-
-### Saudi Arabia
-
-* 'HZ-WBT7' : 'Prince Al Waleed's Boeing 747'
-* 'HZ-WBT5' : 'Prince Al Waleed's Hawker'
-* 'HZ-HMS2' : 'A340 for use by the royal family'
-* 'HZ-HMS1' : 'B747 registered to Prince Sultan Bin Abdulaziz'
-* 'HZ-HM1B' : 'B747 for the use of the Saudi family'
-* 'HZ-HM1A' : 'B747 for the use of the Saudi family'
-* 'HZ-HM1C' : 'B747 for the use of the Saudi family'
-
-### Sudan
-
-* 'ST-PRM' : 'An-72 of the Sudanese government'
-* 'ST-PRA' : 'Il-62 used by Omar Al-Bashir'
-
-### Turkmenistan
-* 'EZ-A777' : 'Boeing 777 VIP used by Turkmenistan government'
-* 'EZ-A007' : 'Boeing 737 VIP used by Turkmenistan government'
-* 'EZ-B024' : 'Challenger 870 used by Turkmenistan government'
+## Media
+* [The Verge](http://www.theverge.com/2016/10/13/13243072/twitter-bot-tracks-dictator-planes-geneva-gva-tracker)

--- a/aragge.js
+++ b/aragge.js
@@ -4,7 +4,7 @@ var request = require('request');
 
 var Twitter = require('twitter');
 var time = require('time')(Date);
- 
+
 var client = new Twitter({
   consumer_key: process.env.TWITTER_CONSUMER_KEY,
   consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
@@ -77,7 +77,7 @@ function query(registration, callback) {
     } else {
       callback(error);
     }
-  }); 
+  });
 }
 
 // The following list contains:
@@ -91,21 +91,21 @@ var planes = {
  '7T-VPC' : 'Gulfstream IV used by Algerian government',
  '7T-VPM' : 'Gulfstream IV used by Algerian government',
  '7T-VPG' : 'Gulfstream V used by Algerian government',
- 
+
  // Angola
  'D2-EYU' : 'De Havilland Dash 8 used by Angola government',
  'D2-EEA' : 'De Havilland Dash 8 used by Angola government',
  'D2-EEB' : 'De Havilland Dash 8 used by Angola government',
 
- 
+
  // Azerbaijan
  '4K-AIO1' : 'Boeing 767 "Baku 1" used by Azerbaijan government',
  '4K-AI06' : 'Gulfstream G550 used by Azerbaijan government',
- 
+
  // Belarus
  'EW-001PA' : 'Boeing 737 used by Belarus government',
  'EW-001PB' : 'Boeing 767 used by Belarus government',
- 
+
  //Cameroon
  'TJ-AAC' : 'Boeing 767 used by Cameroon government',
 
@@ -115,24 +115,24 @@ var planes = {
  '3C-LGE' : 'Falcon 50 used by Equatorial Guinea government',
  '3C-LLU' : 'Boeing 767 used by Equatorial Guinea government',
  'CS-TQX' : 'Boeing 777 used by Equatorial Guinea government',
- 
+
  // Gabon
  'TR-KJD' : 'ATR 42M used by Gabonese government',
  'TR-KPR' : 'Boeing 777 VIP used by Gabonese government',
- 
+
  // Ivory Coast
  'TU-VAD' : 'Gulfstream IV used by Ivory Coast government',
  'TU-VAS' : 'A319 VIP used by Ivory Coast government',
 
  //Jordan
  'VQ-BDD' : 'Airbus A318 Elite used by Jordanian government',
- 
- // Kazakhstan	
- 'P4-KAZ' : 'Boeing 737 used by Kazakhstan government',
+
+ // Kazakhstan
+ 'P4-KAZ'   : 'Boeing 737 used by Kazakhstan government',
  'UP-A2001' : 'Airbus A320 used by Kazakhstan government',
  'UP-A3001' : 'Airbus A330 used by Kazakhstan government',
  'UP-B5701' : 'Boeing 757 used by Kazakhstan government',
- 
+
  // Kuwait
  '9K-GBA' : 'Airbus A340 VIP used by Kuwait government',
  '9K-GBB' : 'Airbus A340 VIP used by Kuwait government',
@@ -144,10 +144,10 @@ var planes = {
  '9K-AJE' : 'Gulfstream V used by Kuwait government',
  '9K-AJF' : 'Gulfstream V used by Kuwait government',
  '9K-GFA' : 'Gulfstream 550 used by Kuwait government',
- 
+
  // Libya
  '5A-ONE' : 'Airbus A340 used by Libyan government',
- 
+
  // Russia
  'RA-96016' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
  'RA-96017' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
@@ -157,12 +157,12 @@ var planes = {
  'HZ-WBT7' : 'Prince Al Waleed\'s Boeing 747',
  'HZ-WBT5' : 'Prince Al Waleed\'s Hawker',
  // "Saudi Arabian Royal Flight" planes operate for the ruling family
- 'HZ-HMS2' : 'A340 for use by the royal family',
- 'HZ-HMS1' : 'B747 registered to Prince Sultan Bin Abdulaziz',
- 'HZ-HM1B' : 'B747 for the use of the royal family',
- 'HZ-HM1A' : 'B747 for the use of the royal family',
- 'HZ-HM1C' : 'B747 for the use of the royal family',
- 
+ 'HZ-HMS2' : 'Airbus A340 for use by the royal family',
+ 'HZ-HMS1' : 'Boeing 747 registered to Prince Sultan Bin Abdulaziz',
+ 'HZ-HM1B' : 'Boeing 747 for the use of the royal family',
+ 'HZ-HM1A' : 'Boeing 747 for the use of the royal family',
+ 'HZ-HM1C' : 'Boeing 747 for the use of the royal family',
+
  // Turkmenistan
  'EZ-A777' : 'Boeing 777 VIP used by Turkmenistan government',
  'EZ-A007' : 'Boeing 737 VIP used by Turkmenistan government',
@@ -182,44 +182,53 @@ var planes = {
  'A7-AAM' : 'Bombardier BD-700 used by the royal family of Qatar',
  'A7-AFE' : 'A310 used by the royal family of Qatar',
  'A7-HHE' : 'Boeing 747 used by the royal family of Qatar',
- 'A7-HHH' : 'A340 used by the royal family of Qatar',
- 'A7-HHJ' : 'A319 used by the royal family of Qatar',
- 'A7-HHK' : 'A340 used by the royal family of Qatar',
- 'A7-HHM' : 'A330 used by the royal family of Qatar',
- 'A7-HJJ' : 'A330 used by the royal family of Qatar',
- 'A7-HSJ' : 'A320 used by the royal family of Qatar',
- 'A7-MBK' : 'A320 used by the royal family of Qatar',
- 'A7-MED' : 'A319 used by the royal family of Qatar',
- 'A7-MHH' : 'A319 used by the royal family of Qatar',
+ 'A7-HHH' : 'Airbus A340 used by the royal family of Qatar',
+ 'A7-HHJ' : 'Airbus A319 used by the royal family of Qatar',
+ 'A7-HHK' : 'Airbus A340 used by the royal family of Qatar',
+ 'A7-HHM' : 'Airbus A330 used by the royal family of Qatar',
+ 'A7-HJJ' : 'Airbus A330 used by the royal family of Qatar',
+ 'A7-HSJ' : 'Airbus A320 used by the royal family of Qatar',
+ 'A7-MBK' : 'Airbus A320 used by the royal family of Qatar',
+ 'A7-MED' : 'Airbus A319 used by the royal family of Qatar',
+ 'A7-MHH' : 'Airbus A319 used by the royal family of Qatar',
  'VP-BAT' : 'Boeing 747 used by the royal family of Qatar',
 
  // Sudan
  // Source: http://www.airplane-pictures.net/photo/465501/st-prm-sudan-government-antonov-an-72/
- 'ST-PRM' : 'An-72 of the Sudanese government',
+ 'ST-PRM' : 'Antonov An-72 of the Sudanese government',
  // Source: http://www.philstar.com/world/2015/09/02/1495088/china-parade-draws-putin-few-other-major-world-leaders
- 'ST-PRA' : 'Il-62 used by Omar Al-Bashir',
+ 'ST-PRA' : 'Ilyushin Il-62 used by Omar Al-Bashir',
 
  // Oman
  // The Royal Flight of Oman caters for the need of the royals
- 'A4O-AJ' : 'A319 of the Oman royal family',
- 'A4O-AA' : 'A320 of the Oman royal family',
- 'A4O-OMN' : 'B747 of the Oman royal family',
- 'A4O-HMS' : 'B747 of the Oman royal family',
- 'A4O-SO' : 'B747 of the Oman royal family',
- 'A4O-AD' : 'Gulfstream of the Oman royal family',
- 'A4O-AE' : 'Gulfstream of the Oman royal family',
+ 'A4O-AJ'  : 'Airbus A319 of the Oman royal family',
+ 'A4O-AA'  : 'Airbus A320 of the Oman royal family',
+ 'A4O-OMN' : 'Boeing 747 of the Oman royal family',
+ 'A4O-HMS' : 'Boeing 747 of the Oman royal family',
+ 'A4O-SO'  : 'Boeing 747 of the Oman royal family',
+ 'A4O-AD'  : 'Gulfstream G550 of the Oman royal family',
+ 'A4O-AE'  : 'Gulfstream G550 of the Oman royal family',
 
  // Algeria
  // Source: http://www.liberation.fr/planete/2014/11/15/le-president-algerien-bouteflika-a-quitte-la-clinique-de-grenoble_1143663
- '7T-VPM' : 'Gulfstream used by the Algerian government',
+ '7T-VPM' : 'Gulfstream IV used by the Algerian government',
 
  // Chad
  // Source: http://www.airteamimages.com/mcdonnell-douglas-md-80_TT-ABC_chad-government_93128.html
- 'TT-ABC' : 'MD-87 used by the government of Chad'
+ 'TT-ABC' : 'MD-87 used by the government of Chad',
+
+ // Iran
+ // Source: http://www.airplane-pictures.net/operator.php?p=3680
+ // http://www.airfleets.net/flottecie/Iranian%20Gvmt.htm
+ 'EP-AJA' : 'Airbus A340 used by the Iran government',
+ 'EP-AJC' : 'Airbus A320 used by the Iran government',
+ 'EP-AJD' : 'Boeing 707 used by the Iran government',
+ 'EP-AGA' : 'Boeing 737 used by the Iran government',
+ 'EP-AGB' : 'Airbus A321 used by the Iran government',
+ 'EP-TFI' : 'Dassault Falcon 50 used by the Iran government'
 };
 
 var testPlanes = { 'HB-JXA' : 1, 'HB-JYN': 1 };
-
 
 function tweet(str) {
   client.post('statuses/update', {status: str}, function(error, tweet, response){
@@ -240,7 +249,7 @@ query(process.argv[2], function(error, flights) {
       var reg = flight['Reg.'];
       if (process.argv[2] || reg in planes) {
         var verb = (flight.M_Type.match(/Landing/) ? 'landed at' : 'left');
-        var str = 
+        var str =
           (reg in testPlanes ? '(test) A plane' : 'A dictator\'s plane')
           + ' ' + verb + ' #gva airport: '
           + (reg in planes && planes[reg] ? planes[reg] + " (" + reg +')' : reg)
@@ -249,8 +258,5 @@ query(process.argv[2], function(error, flights) {
         tweet(str);
       }
     }
-  } 
+  }
 });
-
-
-

--- a/aragge.js
+++ b/aragge.js
@@ -84,148 +84,144 @@ function query(registration, callback) {
 // 'registration ID' : 'Owner'
 var planes = {
   // Algeria
- '7T-VPP' : 'Airbus A340 VIP used by Algerian government',
- '7T-VPF' : 'ATR42 used by Algerian government',
- '7T-VPE' : 'ATR42 used by Algerian government',
- '7T-VPS' : 'Gulfstream IV used by Algerian government',
- '7T-VPC' : 'Gulfstream IV used by Algerian government',
- '7T-VPM' : 'Gulfstream IV used by Algerian government',
- '7T-VPG' : 'Gulfstream V used by Algerian government',
+  // Source: http://www.liberation.fr/planete/2014/11/15/le-president-algerien-bouteflika-a-quitte-la-clinique-de-grenoble_1143663
+  '7T-VPP' : 'Airbus A340 VIP used by Algerian government',
+  '7T-VPF' : 'ATR42 used by Algerian government',
+  '7T-VPE' : 'ATR42 used by Algerian government',
+  '7T-VPS' : 'Gulfstream IV used by Algerian government',
+  '7T-VPC' : 'Gulfstream IV used by Algerian government',
+  '7T-VPM' : 'Gulfstream IV used by Algerian government',
+  '7T-VPG' : 'Gulfstream V used by Algerian government',
 
- // Angola
- 'D2-EYU' : 'De Havilland Dash 8 used by Angola government',
- 'D2-EEA' : 'De Havilland Dash 8 used by Angola government',
- 'D2-EEB' : 'De Havilland Dash 8 used by Angola government',
+  // Angola
+  'D2-EYU' : 'De Havilland Dash 8 used by Angola government',
+  'D2-EEA' : 'De Havilland Dash 8 used by Angola government',
+  'D2-EEB' : 'De Havilland Dash 8 used by Angola government',
 
+  // Azerbaijan
+  '4K-AIO1' : 'Boeing 767 "Baku 1" used by Azerbaijan government',
+  '4K-AI06' : 'Gulfstream G550 used by Azerbaijan government',
 
- // Azerbaijan
- '4K-AIO1' : 'Boeing 767 "Baku 1" used by Azerbaijan government',
- '4K-AI06' : 'Gulfstream G550 used by Azerbaijan government',
+  // Bahrain
+  // Source: https://www.youtube.com/watch?v=XlRT3ruTnkU
+  'A9C-HMK' : 'Boeing 747 used by the king of Bahrain',
 
- // Belarus
- 'EW-001PA' : 'Boeing 737 used by Belarus government',
- 'EW-001PB' : 'Boeing 767 used by Belarus government',
+  // Belarus
+  'EW-001PA' : 'Boeing 737 used by Belarus government',
+  'EW-001PB' : 'Boeing 767 used by Belarus government',
 
- //Cameroon
- 'TJ-AAC' : 'Boeing 767 used by Cameroon government',
+  // Cameroon
+  'TJ-AAC' : 'Boeing 767 used by Cameroon government',
 
- // Equatorial Guinea
- '3C-EGE' : 'Boeing 737 used by Teodoro Obiang, Equatorial Guinea',
- '3C-ONM' : 'Dassault 900B used by Teodorin Obiang, Equatorial Guinea',
- '3C-LGE' : 'Falcon 50 used by Equatorial Guinea government',
- '3C-LLU' : 'Boeing 767 used by Equatorial Guinea government',
- 'CS-TQX' : 'Boeing 777 used by Equatorial Guinea government',
+  // Chad
+  // Source: http://www.airteamimages.com/mcdonnell-douglas-md-80_TT-ABC_chad-government_93128.html
+  'TT-ABC' : 'MD-87 used by the government of Chad',
 
- // Gabon
- 'TR-KJD' : 'ATR 42M used by Gabonese government',
- 'TR-KPR' : 'Boeing 777 VIP used by Gabonese government',
+  // Equatorial Guinea
+  '3C-EGE' : 'Boeing 737 used by Teodoro Obiang, Equatorial Guinea',
+  '3C-ONM' : 'Dassault 900B used by Teodorin Obiang, Equatorial Guinea',
+  '3C-LGE' : 'Falcon 50 used by Equatorial Guinea government',
+  '3C-LLU' : 'Boeing 767 used by Equatorial Guinea government',
+  'CS-TQX' : 'Boeing 777 used by Equatorial Guinea government',
 
- // Ivory Coast
- 'TU-VAD' : 'Gulfstream IV used by Ivory Coast government',
- 'TU-VAS' : 'A319 VIP used by Ivory Coast government',
+  // Gabon
+  'TR-KJD' : 'ATR 42M used by Gabonese government',
+  'TR-KPR' : 'Boeing 777 VIP used by Gabonese government',
 
- //Jordan
- 'VQ-BDD' : 'Airbus A318 Elite used by Jordanian government',
+  // Iran
+  // Source: http://www.airplane-pictures.net/operator.php?p=3680
+  // http://www.airfleets.net/flottecie/Iranian%20Gvmt.htm
+  'EP-AJA' : 'Airbus A340 used by the Iran government',
+  'EP-AJC' : 'Airbus A320 used by the Iran government',
+  'EP-AJD' : 'Boeing 707 used by the Iran government',
+  'EP-AGA' : 'Boeing 737 used by the Iran government',
+  'EP-AGB' : 'Airbus A321 used by the Iran government',
+  'EP-TFI' : 'Dassault Falcon 50 used by the Iran government',
 
- // Kazakhstan
- 'P4-KAZ'   : 'Boeing 737 used by Kazakhstan government',
- 'UP-A2001' : 'Airbus A320 used by Kazakhstan government',
- 'UP-A3001' : 'Airbus A330 used by Kazakhstan government',
- 'UP-B5701' : 'Boeing 757 used by Kazakhstan government',
+  // Ivory Coast
+  'TU-VAD' : 'Gulfstream IV used by Ivory Coast government',
+  'TU-VAS' : 'A319 VIP used by Ivory Coast government',
 
- // Kuwait
- '9K-GBA' : 'Airbus A340 VIP used by Kuwait government',
- '9K-GBB' : 'Airbus A340 VIP used by Kuwait government',
- '9K-AKD' : 'Airbus A320 VIP used by Kuwait government',
- '9K-GEA' : 'Airbus A319 VIP used by Kuwait government',
- '9K-GCC' : 'Boeing 737 VIP used by Kuwait government',
- '9K-GAA' : 'Boeing 747 VIP used by Kuwait government',
- '9K-AJD' : 'Gulfstream V used by Kuwait government',
- '9K-AJE' : 'Gulfstream V used by Kuwait government',
- '9K-AJF' : 'Gulfstream V used by Kuwait government',
- '9K-GFA' : 'Gulfstream 550 used by Kuwait government',
+  // Jordan
+  'VQ-BDD' : 'Airbus A318 Elite used by Jordanian government',
 
- // Libya
- '5A-ONE' : 'Airbus A340 used by Libyan government',
+  // Kazakhstan
+  'P4-KAZ'   : 'Boeing 737 used by Kazakhstan government',
+  'UP-A2001' : 'Airbus A320 used by Kazakhstan government',
+  'UP-A3001' : 'Airbus A330 used by Kazakhstan government',
+  'UP-B5701' : 'Boeing 757 used by Kazakhstan government',
 
- // Russia
- 'RA-96016' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
- 'RA-96017' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
+  // Kuwait
+  '9K-GBA' : 'Airbus A340 VIP used by Kuwait government',
+  '9K-GBB' : 'Airbus A340 VIP used by Kuwait government',
+  '9K-AKD' : 'Airbus A320 VIP used by Kuwait government',
+  '9K-GEA' : 'Airbus A319 VIP used by Kuwait government',
+  '9K-GCC' : 'Boeing 737 VIP used by Kuwait government',
+  '9K-GAA' : 'Boeing 747 VIP used by Kuwait government',
+  '9K-AJD' : 'Gulfstream V used by Kuwait government',
+  '9K-AJE' : 'Gulfstream V used by Kuwait government',
+  '9K-AJF' : 'Gulfstream V used by Kuwait government',
+  '9K-GFA' : 'Gulfstream 550 used by Kuwait government',
 
- // Saudi Arabia
- // Source: http://i.dailymail.co.uk/i/pix/2015/07/01/16/2A25797C00000578-3145792-The_prince_has_several_planes_including_the_smaller_A_Hawker_jet-a-12_1435765095892.jpg
- 'HZ-WBT7' : 'Prince Al Waleed\'s Boeing 747',
- 'HZ-WBT5' : 'Prince Al Waleed\'s Hawker',
- // "Saudi Arabian Royal Flight" planes operate for the ruling family
- 'HZ-HMS2' : 'Airbus A340 for use by the royal family',
- 'HZ-HMS1' : 'Boeing 747 registered to Prince Sultan Bin Abdulaziz',
- 'HZ-HM1B' : 'Boeing 747 for the use of the royal family',
- 'HZ-HM1A' : 'Boeing 747 for the use of the royal family',
- 'HZ-HM1C' : 'Boeing 747 for the use of the royal family',
+  // Libya
+  '5A-ONE' : 'Airbus A340 used by Libyan government',
 
- // Turkmenistan
- 'EZ-A777' : 'Boeing 777 VIP used by Turkmenistan government',
- 'EZ-A007' : 'Boeing 737 VIP used by Turkmenistan government',
- 'EZ-B024' : 'Challenger 870 used by Turkmenistan government',
+  // Oman
+  // The Royal Flight of Oman caters for the need of the royals
+  'A4O-AJ'  : 'Airbus A319 of the Oman royal family',
+  'A4O-AA'  : 'Airbus A320 of the Oman royal family',
+  'A4O-OMN' : 'Boeing 747 of the Oman royal family',
+  'A4O-HMS' : 'Boeing 747 of the Oman royal family',
+  'A4O-SO'  : 'Boeing 747 of the Oman royal family',
+  'A4O-AD'  : 'Gulfstream G550 of the Oman royal family',
+  'A4O-AE'  : 'Gulfstream G550 of the Oman royal family',
 
- // Bahrain
- // Source: https://www.youtube.com/watch?v=XlRT3ruTnkU
- 'A9C-HMK' : 'Boeing 747 used by the king of Bahrain',
+  // Qatar
+  // Source https://www.youtube.com/watch?v=-BCVLX7Pdfc
+  // https://en.wikipedia.org/wiki/Qatar_Amiri_Flight
+  // http://www.airframes.org/fleet/qaf
+  'VQ-BSK' : 'Boeing 747 used by the royal family of Qatar',
+  'A7-AAG' : 'A320 used by the royal family of Qatar',
+  'A7-AAH' : 'A340 used by the royal family of Qatar',
+  'A7-AAM' : 'Bombardier BD-700 used by the royal family of Qatar',
+  'A7-AFE' : 'A310 used by the royal family of Qatar',
+  'A7-HHE' : 'Boeing 747 used by the royal family of Qatar',
+  'A7-HHH' : 'Airbus A340 used by the royal family of Qatar',
+  'A7-HHJ' : 'Airbus A319 used by the royal family of Qatar',
+  'A7-HHK' : 'Airbus A340 used by the royal family of Qatar',
+  'A7-HHM' : 'Airbus A330 used by the royal family of Qatar',
+  'A7-HJJ' : 'Airbus A330 used by the royal family of Qatar',
+  'A7-HSJ' : 'Airbus A320 used by the royal family of Qatar',
+  'A7-MBK' : 'Airbus A320 used by the royal family of Qatar',
+  'A7-MED' : 'Airbus A319 used by the royal family of Qatar',
+  'A7-MHH' : 'Airbus A319 used by the royal family of Qatar',
+  'VP-BAT' : 'Boeing 747 used by the royal family of Qatar',
 
- // Qatar
- // Source https://www.youtube.com/watch?v=-BCVLX7Pdfc
- // https://en.wikipedia.org/wiki/Qatar_Amiri_Flight
- // http://www.airframes.org/fleet/qaf
- 'VQ-BSK' : 'Boeing 747 used by the royal family of Qatar',
- 'A7-AAG' : 'A320 used by the royal family of Qatar',
- 'A7-AAH' : 'A340 used by the royal family of Qatar',
- 'A7-AAM' : 'Bombardier BD-700 used by the royal family of Qatar',
- 'A7-AFE' : 'A310 used by the royal family of Qatar',
- 'A7-HHE' : 'Boeing 747 used by the royal family of Qatar',
- 'A7-HHH' : 'Airbus A340 used by the royal family of Qatar',
- 'A7-HHJ' : 'Airbus A319 used by the royal family of Qatar',
- 'A7-HHK' : 'Airbus A340 used by the royal family of Qatar',
- 'A7-HHM' : 'Airbus A330 used by the royal family of Qatar',
- 'A7-HJJ' : 'Airbus A330 used by the royal family of Qatar',
- 'A7-HSJ' : 'Airbus A320 used by the royal family of Qatar',
- 'A7-MBK' : 'Airbus A320 used by the royal family of Qatar',
- 'A7-MED' : 'Airbus A319 used by the royal family of Qatar',
- 'A7-MHH' : 'Airbus A319 used by the royal family of Qatar',
- 'VP-BAT' : 'Boeing 747 used by the royal family of Qatar',
+  // Russia
+  'RA-96016' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
+  'RA-96017' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
 
- // Sudan
- // Source: http://www.airplane-pictures.net/photo/465501/st-prm-sudan-government-antonov-an-72/
- 'ST-PRM' : 'Antonov An-72 of the Sudanese government',
- // Source: http://www.philstar.com/world/2015/09/02/1495088/china-parade-draws-putin-few-other-major-world-leaders
- 'ST-PRA' : 'Ilyushin Il-62 used by Omar Al-Bashir',
+  // Saudi Arabia
+  // Source: http://i.dailymail.co.uk/i/pix/2015/07/01/16/2A25797C00000578-3145792-The_prince_has_several_planes_including_the_smaller_A_Hawker_jet-a-12_1435765095892.jpg
+  // "Saudi Arabian Royal Flight" planes operate for the ruling family
+  'HZ-WBT7' : 'Prince Al Waleed\'s Boeing 747',
+  'HZ-WBT5' : 'Prince Al Waleed\'s Hawker',
+  'HZ-HMS2' : 'Airbus A340 for use by the royal family',
+  'HZ-HMS1' : 'Boeing 747 registered to Prince Sultan Bin Abdulaziz',
+  'HZ-HM1B' : 'Boeing 747 for the use of the royal family',
+  'HZ-HM1A' : 'Boeing 747 for the use of the royal family',
+  'HZ-HM1C' : 'Boeing 747 for the use of the royal family',
 
- // Oman
- // The Royal Flight of Oman caters for the need of the royals
- 'A4O-AJ'  : 'Airbus A319 of the Oman royal family',
- 'A4O-AA'  : 'Airbus A320 of the Oman royal family',
- 'A4O-OMN' : 'Boeing 747 of the Oman royal family',
- 'A4O-HMS' : 'Boeing 747 of the Oman royal family',
- 'A4O-SO'  : 'Boeing 747 of the Oman royal family',
- 'A4O-AD'  : 'Gulfstream G550 of the Oman royal family',
- 'A4O-AE'  : 'Gulfstream G550 of the Oman royal family',
+  // Sudan
+  // Source: http://www.airplane-pictures.net/photo/465501/st-prm-sudan-government-antonov-an-72
+  // http://www.philstar.com/world/2015/09/02/1495088/china-parade-draws-putin-few-other-major-world-leaders
+  'ST-PRM' : 'Antonov An-72 of the Sudanese government',
+  'ST-PRA' : 'Ilyushin Il-62 used by Omar Al-Bashir',
 
- // Algeria
- // Source: http://www.liberation.fr/planete/2014/11/15/le-president-algerien-bouteflika-a-quitte-la-clinique-de-grenoble_1143663
- '7T-VPM' : 'Gulfstream IV used by the Algerian government',
-
- // Chad
- // Source: http://www.airteamimages.com/mcdonnell-douglas-md-80_TT-ABC_chad-government_93128.html
- 'TT-ABC' : 'MD-87 used by the government of Chad',
-
- // Iran
- // Source: http://www.airplane-pictures.net/operator.php?p=3680
- // http://www.airfleets.net/flottecie/Iranian%20Gvmt.htm
- 'EP-AJA' : 'Airbus A340 used by the Iran government',
- 'EP-AJC' : 'Airbus A320 used by the Iran government',
- 'EP-AJD' : 'Boeing 707 used by the Iran government',
- 'EP-AGA' : 'Boeing 737 used by the Iran government',
- 'EP-AGB' : 'Airbus A321 used by the Iran government',
- 'EP-TFI' : 'Dassault Falcon 50 used by the Iran government'
+  // Turkmenistan
+  'EZ-A777' : 'Boeing 777 VIP used by Turkmenistan government',
+  'EZ-A007' : 'Boeing 737 VIP used by Turkmenistan government',
+  'EZ-B024' : 'Challenger 870 used by Turkmenistan government'
 };
 
 var testPlanes = { 'HB-JXA' : 1, 'HB-JYN': 1 };


### PR DESCRIPTION
Added Iran's government fleet by cross checking information between: [Airplane-Pictures.net](http://airplane-pictures.net), [Flightradar24](https://www.flightradar24.com/data/aircraft), [Airframes](http://www.airframes.org), [Plane Finder Data](https://planefinder.net/data) and [PlaneLogger](https://www.planelogger.com).

Also, I did some changes on aircraft names.
