### PR TITLE
From Belarus with love

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ To read more about the Democracy Index, consult: [Democracy Index - Wikipedia](h
 * [@nicolaskb](https://twitter.com/nicolaskb)
 * [@julienpilet](https://twitter.com/julienpilet)
 * [@francoispilet](https://twitter.com/francoispilet)
+* [@jcdenton__](https://twitter.com/jcdenton__)
 
 ## Media
 * [Newsweek](http://europe.newsweek.com/twitter-bot-tracks-flights-switzerland-gva-dictator-alert-509513?rm=eu): Twitter Bot Track Dictators' Flights To Switzerland

--- a/README.md
+++ b/README.md
@@ -122,8 +122,22 @@ To read more about the Democracy Index, consult: [Democracy Index - Wikipedia](h
 * **VP-BAT**: Boeing 747 used by the royal family of Qatar
 
 ### Russia
-* **RA-96016**: Ilyushin Il-96 used Russian president Vladimir Putin
-* **RA-96017**: Ilyushin Il-96 used Russian president Vladimir Putin
+* **RA-87968**: Yakovlev Yak-40 used by Russian government
+* **RA-87972**: Yakovlev Yak-40 used by Russian government
+* **RA-65905**: Tupolev Tu-134 used by Russian government
+* **RA-65911**: Tupolev Tu-134 used by Russian government
+* **RA-64517**: Tupolev Tu-214 used by Russian government
+* **RA-64520**: Tupolev Tu-214 used by Russian government
+* **RA-64522**: Tupolev Tu-214 used by Russian government
+* **RA-64524**: Tupolev Tu-214 used by Russian government
+* **RA-96012**: Ilyushin Il-96 used by Russian government
+* **RA-96016**: Ilyushin Il-96 used by Russian government
+* **RA-96017**: Ilyushin Il-96 used by Russian government
+* **RA-96018**: Ilyushin Il-96 used by Russian government
+* **RA-96019**: Ilyushin Il-96 used by Russian government
+* **RA-96020**: Ilyushin Il-96 used by Russian president Vladimir Putin
+* **RA-96021**: Ilyushin Il-96 used by Russian president Vladimir Putin
+* **M-VQBI**: Bombardier Global 6000 used by Russian Vice Prime Minister Igor Shuvalov and his family
 
 ### Saudi Arabia
 * **HZ-WBT7**: Prince Al Waleed's Boeing 747

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To read more about the Democracy Index, consult: [Democracy Index - Wikipedia](h
 ### Belarus
 * **EW-001PA**: Boeing 737 used by Belarus government
 * **EW-001PB**: Boeing 767 used by Belarus government
+* **EW-85815**: Tupolev Tu-154M used by Belarus government
 
 ### Cameroon
 * **TJ-AAC**: Boeing 767 used by Cameroon government

--- a/aragge.js
+++ b/aragge.js
@@ -199,8 +199,25 @@ var planes = {
   'VP-BAT' : 'Boeing 747 used by the royal family of Qatar',
 
   // Russia
-  'RA-96016' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
-  'RA-96017' : 'Ilyushin Il-96 used Russian president Vladimir Putin',
+  // Source for most of them (in Russian and I'm too lazy to translate, but you can use Google Translate): https://goo.gl/Z7Yjyi
+  'RA-87968' : 'Yakovlev Yak-40 used by Russian government',
+  'RA-87972' : 'Yakovlev Yak-40 used by Russian government',
+  'RA-65905' : 'Tupolev Tu-134 used by Russian government',
+  'RA-65911' : 'Tupolev Tu-134 used by Russian government',
+  'RA-64517' : 'Tupolev Tu-214 used by Russian government',
+  'RA-64520' : 'Tupolev Tu-214 used by Russian government',
+  'RA-64522' : 'Tupolev Tu-214 used by Russian government',
+  'RA-64524' : 'Tupolev Tu-214 used by Russian government',
+  // All of them including RA-96012, RA-96016..19 could be checked at https://www.flightradar24.com/data/aircraft/RA-96012
+  'RA-96012' : 'Ilyushin Il-96 used by Russian government',
+  'RA-96016' : 'Ilyushin Il-96 used by Russian government',
+  'RA-96017' : 'Ilyushin Il-96 used by Russian government',
+  'RA-96018' : 'Ilyushin Il-96 used by Russian government',
+  'RA-96019' : 'Ilyushin Il-96 used by Russian government',
+  'RA-96020' : 'Ilyushin Il-96 used by Russian president Vladimir Putin',
+  'RA-96021' : 'Ilyushin Il-96 used by Russian president Vladimir Putin',
+  // Source (Google Translate is better than nothing): https://navalny.com/p/4952/
+  'M-VQBI' : 'Bombardier Global 6000 used by Russian Vice Prime Minister Igor Shuvalov and his family'
 
   // Saudi Arabia
   // Source: http://i.dailymail.co.uk/i/pix/2015/07/01/16/2A25797C00000578-3145792-The_prince_has_several_planes_including_the_smaller_A_Hawker_jet-a-12_1435765095892.jpg

--- a/aragge.js
+++ b/aragge.js
@@ -109,6 +109,7 @@ var planes = {
   // Belarus
   'EW-001PA' : 'Boeing 737 used by Belarus government',
   'EW-001PB' : 'Boeing 767 used by Belarus government',
+  'EW-85815' : 'Tupolev Tu-154M used by Belarus government',
 
   // Cameroon
   'TJ-AAC' : 'Boeing 767 used by Cameroon government',


### PR DESCRIPTION
First of all, one Belarusian aircraft was missing on the list.

For the second, I thought it would be unfair to include only 2 of Putin's aircrafts since he has a whole fleet (7 pcs. of only Il-96!). There is a whole Wiki article about that Special Airforce (sorry for Russian, but you could try using Google Translate) https://ru.wikipedia.org/wiki/Специальный_лётный_отряд_«Россия»
Looks like Mr. Putin and co. also has a bunch of Mi-8 helicopters, but I doubt they use them for international flights. 

And a cherry atop the cake - First Deputy Russian Prime Minister [Shuvalov's own private Bombardier Global 6000](https://meduza.io/en/news/2016/07/14/anti-corruption-leader-publishes-evidence-that-russia-s-first-deputy-prime-minister-spends-millions-on-private-airplanes) used mostly to visit his house in Salzburg or [doge shows and competitions :3](http://www.dailymail.co.uk/news/article-3695649/Vladimir-Putin-s-crony-flies-wife-s-prized-Corgis-PRIVATE-JET-business-just-class-uncomfortable-them.html)
