### PR TITLE
Adding North Korea

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ To read more about the Democracy Index, consult: [Democracy Index - Wikipedia](h
 ### Libya
 * **5A-ONE**: Airbus A340 used by Libyan government
 
+### North Korea
+* **P-618**: Ilyushin Il-62M used by North Korean government
+* **P-885**: Ilyushin Il-62M used by North Korean government
+
 ### Oman
 * **A4O-AJ**: Airbus A319 of the Oman royal family
 * **A4O-AA**: Airbus A320 of the Oman royal family

--- a/planes.json
+++ b/planes.json
@@ -134,6 +134,18 @@
   }
 },
 {
+  "country": "North Korea",
+  "source": [
+    "https://www.flightradar24.com/data/aircraft/air-koryo-js-kor",
+    "https://en.wikipedia.org/wiki/Air_transports_of_heads_of_state_and_government#North_Korea_2"
+  ],
+  "comment": "Air Koryo planes operate for the North Korean government",
+  "planes": {
+    "P-618" : "Ilyushin Il-62M used by North Korean government",
+    "P-885" : "Ilyushin Il-62M used by North Korean government"
+  }
+},
+{
   "country": "Oman",
   "comment": "The Royal Flight of Oman caters for the need of the royals",
   "planes": {


### PR DESCRIPTION
Based on:
[Air transports of heads of state and government](https://en.wikipedia.org/wiki/Air_transports_of_heads_of_state_and_government#North_Korea_2)
[Flightradar24](https://www.flightradar24.com/data/aircraft/air-koryo-js-kor) : [P-618](https://www.flightradar24.com/data/aircraft/p-618), [P-885](https://www.flightradar24.com/data/aircraft/p-885)
PlaneLogger : [P-618](https://www.planelogger.com/Aircraft/Registration/P-618/722637), [P-885](https://www.planelogger.com/Aircraft/Registration/P-885/722401)
